### PR TITLE
Challenge 2 - Store data in the database

### DIFF
--- a/modules/custom/inope_policy_review/inope_policy_review.install
+++ b/modules/custom/inope_policy_review/inope_policy_review.install
@@ -59,8 +59,8 @@ function inope_policy_review_schema() {
     'indexes' => array(
       'note_active' => array(
         'nid',
-        'note_status',
         'uid',
+        'note_submitted',
       ),
     ),
     'foreign keys' => array(

--- a/modules/custom/inope_policy_review/inope_policy_review.install
+++ b/modules/custom/inope_policy_review/inope_policy_review.install
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the inope_policy_review module.
+ */
+
+/**
+ * Implements hook_schema().
+ */
+function inope_policy_review_schema() {
+  $schema['policy_review'] = array(
+    'description' => 'The table for policy reviews.',
+    'fields' => array(
+      'policy_review_id' => array(
+        'description' => 'The primary identifier for a policy review note.',
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ),
+      'vid' => array(
+        'description' => 'The current node vid.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => FALSE,
+      ),
+      'nid' => array(
+        'description' => 'The current node nid.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => FALSE,
+      ),
+      'uid' => array(
+        'description' => 'The current user uid.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => FALSE,
+      ),
+      'note_status' => array(
+        'description' => 'Boolean indicating the note status.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'note_submitted' => array(
+        'description' => 'The Unix timestamp when the note was submitted.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'note' => array(
+        'description' => 'A brief policy review note.',
+        'type' => 'text',
+        'not null' => TRUE,
+        'size' => 'medium',
+        'translatable' => TRUE,
+      ),
+    ),
+    'indexes' => array(
+      'note_active' => array(
+        'nid',
+        'note_status',
+        'uid',
+      ),
+    ),
+    'foreign keys' => array(
+      'node' => array(
+        'table' => 'node',
+        'columns' => array('nid' => 'nid'),
+      ),
+      'users' => array(
+        'table' => 'users',
+        'columns' => array('uid' => 'uid'),
+      ),
+    ),
+    'primary key' => array('policy_review_id'),
+  );
+  return $schema;
+}
+
+/**
+ * Install the schema.
+ *
+ * Note that we only need to do this while upgrading as drupal_install_schema
+ * is called by default in hook_install().
+ */
+function inope_policy_review_update_7000() {
+  // Install the schema if the table does not exist.  This prevents the install
+  // hook from running twice.
+  if (db_table_exists('policy_review') == FALSE) {
+    drupal_install_schema('inope_policy_review');
+  }
+}

--- a/modules/custom/inope_policy_review/inope_policy_review.install
+++ b/modules/custom/inope_policy_review/inope_policy_review.install
@@ -84,7 +84,7 @@ function inope_policy_review_schema() {
  * Note that we only need to do this while upgrading as drupal_install_schema
  * is called by default in hook_install().
  */
-function inope_policy_review_update_7000() {
+function inope_policy_review_update_7100() {
   // Install the schema if the table does not exist.  This prevents the install
   // hook from running twice.
   if (db_table_exists('policy_review') == FALSE) {

--- a/modules/custom/inope_policy_review/inope_policy_review.module
+++ b/modules/custom/inope_policy_review/inope_policy_review.module
@@ -55,10 +55,31 @@ function inope_policy_review_tab_title_callback($node) {
  *   policy nodes.
  */
 function inope_policy_review_page($node) {
-  // Create a build array to be displayed on the page.
-  $build = array(
-    'inope_policy_review_form' => drupal_get_form('inope_policy_review_form', $node),
-  );
+  global $user;
+  $account = $user;
+  $build = array();
+
+  // TODO: Ask client if they want previously submitted approval to be allowed
+  // to be overwritten, this is the current functionality.
+  $results = inope_policy_review_select_query($node, $account, 0);
+
+  // TODO: When the form is rebuilt query above this doesn't pick up the new
+  // entry.
+  // If the active user has previously submitted something only display a
+  // message.
+  if (!empty($results)) {
+    $build['message'] = array(
+      '#type' => 'markup',
+      '#markup' => t('Thank you for your feedback!
+      Please check back often for additional review.'),
+    );
+  } 
+  else {
+    // If no results build a blank form
+    $build['inope_policy_review_form'] 
+      = drupal_get_form('inope_policy_review_form', $node);
+  }
+
   return $build;
 }
 
@@ -72,45 +93,6 @@ function inope_policy_review_permission() {
       'description' => t('View the review tab on policy node pages'),
     ),
   );
-}
-
-/**
- * Implements hook_form_alter().
- */
-function inope_policy_review_form_alter(&$form, &$form_state, $form_id) {
-
-  global $user;
-  $account = $user;
-
-  // Store argument from the autoloader in hook_menu().
-  $node = $form_state['build_info']['args'][0];
-
-  // Check that we are only altering the inope policy review form.
-  if ($form_id == 'inope_policy_review_form') {
-
-    // Query the policy review table for any records related to the current
-    // node, unapproved notes, and are from the current user.
-    $results = db_select('policy_review', 'pr')
-      ->fields('pr')
-      ->condition('nid', $node->nid, '=')
-      ->condition('note_status', 0, '=')
-      ->condition('uid', $account->uid, '=')
-      ->execute()
-      ->fetchAssoc();
-
-    // If the active user has submitted something and is not an administrator
-    // clear the form items we don't want to show and show a message.
-    if (!empty($results) && !in_array('administrator', $account->roles)) {
-      $form['inope_policy_review_status_radio'] = array();
-      $form['inope_policy_review_changes_requested_textarea'] = array();
-      $form['inope_policy_review_submit'] = array();
-      $form['message'] = array(
-        '#type' => 'markup',
-        '#markup' => t('Thank you for your feedback!
-        Please check back often for additional review.'),
-      );
-    }
-  }
 }
 
 /**
@@ -190,60 +172,35 @@ function inope_policy_review_form_submit($form, &$form_state) {
   // Load objects from which their properties will be displayed.
   $account = user_load($form_state['values']['inope_policy_review_hidden_uid']);
   $node = node_load($form_state['values']['inope_policy_review_hidden_nid']);
-
+  $text = check_plain($form_state['values']['inope_policy_review_changes_requested_textarea']);
+  
   // If 'I have reviewed this policy and approved it for use' is selected.
   if ($form_state['values']['inope_policy_review_status_radio'] == 0) {
 
-    // Only administrators should be able to approve notes.
-    if (in_array('administrator', $account->roles)) {
+    $policy_review_id = inope_policy_review_insert_query($node, $account, '', 1);
 
-      // Run an update query on the policy review table to set the note_status
-      // as approved where the fields are equal to the current node and are
-      // unapproved.
-      $updated_records = db_update('policy_review')
-        ->fields(array(
-          'note_status' => 1,
-        ))
-        ->condition('nid', $node->nid, '=')
-        ->condition('note_status', 0, '=')
-        ->execute();
-
-      drupal_set_message(t('Policy approved for use @number records updated', array(
-        '@number' => $updated_records,
-      )));
+    if ($policy_review_id != 0) {
+      // Thank the user for their approval.
+      drupal_set_message(
+        t('Thank you @username for approving the policy', array(
+          '@username' => $account->name,
+        )));
     }
-    // Staff will receive this warning message.
-    else {
-      drupal_set_message(t('Please contact your administrator for approval.'),
-        'warning');
-    }
-
   }
   // If 'I have reviewed this policy and would like to see changes' is selected.
   elseif ($form_state['values']['inope_policy_review_status_radio'] == 1) {
 
-    // Make code more legible by setting a variable here.
-    $text = $form_state['values']['inope_policy_review_changes_requested_textarea'];
+    $policy_review_id = inope_policy_review_insert_query($node, $account, $text, 0);
 
-    // Run an insert query on the policy review table for the new note.
-    $policy_review_id = db_insert('policy_review')
-      ->fields(array(
-        'nid' => $node->nid,
-        'vid' => $node->vid,
-        'uid' => $account->uid,
-        'note_status' => 0,
-        'note_submitted' => time(),
-        'note' => $text,
-      ))
-      ->execute();
-
-    // Thank the user for their request.
-    drupal_set_message(
-      t('Thank you @username for submitting the following change request:', array(
-        '@username' => $account->name,
-      )));
-
-    drupal_set_message($text);
+    if ($policy_review_id != 0) {
+      // Thank the user for their request.
+      drupal_set_message(
+        t('Thank you @username for submitting the following change request:', array(
+          '@username' => $account->name,
+        )));
+      // Check_plain happened when this variable was declared.
+      drupal_set_message($text);
+    }
   }
   // If a bug is encountered.
   else {
@@ -252,4 +209,81 @@ function inope_policy_review_form_submit($form, &$form_state) {
 
   // Rebuild the form.
   $form_state['rebuild'] = TRUE;
+}
+
+/**
+ * Select query for the current node policy review notes.
+ * 
+ * Query the policy review table for any records related to the current
+ * node, note status, and are from the current user.
+ */
+function inope_policy_review_select_query($node, $account, $status) {
+  
+  $results = db_query(
+    "SELECT * FROM {policy_review} WHERE nid = :nid AND note_status =
+     :note_status AND uid = :uid ORDER BY note_submitted DESC", array(
+      ':nid' => $node->nid,
+      ':note_status' => $status,
+      ':uid' => $account->uid,
+    ))->fetchAll();
+  
+  return $results;
+}
+
+/**
+ * Insert query to add a new policy review note or approve policy.
+ * 
+ * Only insert the new row if it is substantially a new request meaning that
+ * some value other than the timestamp is different
+ */
+function inope_policy_review_insert_query($node, $account, $text, $status) {
+  
+  $results = inope_policy_review_select_query($node, $account, $status);
+  
+  // If the entry already exists don't duplicate it
+  if (!empty($results) && 
+      $results[0]->nid == $node->nid &&
+      $results[0]->vid == $node->vid &&
+      $results[0]->uid == $account->uid &&
+      $results[0]->note_status == $status &&
+      $results[0]->note == $text) {
+    drupal_set_message(t('You have previously submitted this response.'));
+    $policy_review_id = 0;
+  }
+  else {
+    // Run an insert query on the policy review table for the new note.
+    $policy_review_id = db_insert('policy_review')
+      ->fields(array(
+        'nid' => $node->nid,
+        'vid' => $node->vid,
+        'uid' => $account->uid,
+        'note_status' => $status,
+        'note_submitted' => time(),
+        'note' => $text,
+      ))
+      ->execute();
+  }
+  
+  return $policy_review_id;
+}
+
+/**
+ * Update query if the user wants to update a record.
+ * 
+ * Currently this funtion is not called anywhere but it is avaliable for future 
+ * use.
+ */
+function inope_policy_review_update_query($node, $account, $text, $timestamp) {
+  
+  // Run an update query on the policy review table to change the note.
+  $updated_records = db_update('policy_review')
+    ->fields(array(
+      'note' => $text,
+    ))
+    ->condition('nid', $node->nid, '=')
+    ->condition('uid', $account->uid, '=')
+    ->condition('note_submitted', $timestamp, '=')
+    ->execute();
+  
+  return $updated_records;
 }

--- a/modules/custom/inope_policy_review/inope_policy_review.module
+++ b/modules/custom/inope_policy_review/inope_policy_review.module
@@ -59,12 +59,9 @@ function inope_policy_review_page($node) {
   $account = $user;
   $build = array();
 
-  // TODO: Ask client if they want previously submitted approval to be allowed
-  // to be overwritten, this is the current functionality.
-  $results = inope_policy_review_select_query($node, $account, 0);
+  // Retreive all notes related to this node and account.
+  $results = inope_policy_review_select_query($node, $account);
 
-  // TODO: When the form is rebuilt query above this doesn't pick up the new
-  // entry.
   // If the active user has previously submitted something only display a
   // message.
   if (!empty($results)) {
@@ -206,9 +203,6 @@ function inope_policy_review_form_submit($form, &$form_state) {
   else {
     drupal_set_message(t('Form state not recognized'));
   }
-
-  // Rebuild the form.
-  $form_state['rebuild'] = TRUE;
 }
 
 /**
@@ -217,16 +211,28 @@ function inope_policy_review_form_submit($form, &$form_state) {
  * Query the policy review table for any records related to the current
  * node, note status, and are from the current user.
  */
-function inope_policy_review_select_query($node, $account, $status) {
+function inope_policy_review_select_query($node, $account, $status = NULL) {
   
-  $results = db_query(
+  // We need the ability to return all records regardless of status so we change
+  // the query based off of status = null or status = something defined.
+  if ($status == NULL) {
+    $results = db_query(
+    "SELECT * FROM {policy_review} WHERE nid = :nid AND uid = :uid ORDER BY 
+     note_submitted DESC", array(
+      ':nid' => $node->nid,
+      ':uid' => $account->uid,
+    ))->fetchAll();
+  } 
+  else {
+    $results = db_query(
     "SELECT * FROM {policy_review} WHERE nid = :nid AND note_status =
      :note_status AND uid = :uid ORDER BY note_submitted DESC", array(
       ':nid' => $node->nid,
       ':note_status' => $status,
       ':uid' => $account->uid,
     ))->fetchAll();
-  
+  }
+    
   return $results;
 }
 

--- a/modules/custom/inope_policy_review/inope_policy_review.module
+++ b/modules/custom/inope_policy_review/inope_policy_review.module
@@ -211,7 +211,7 @@ function inope_policy_review_form_submit($form, &$form_state) {
  * Query the policy review table for any records related to the current
  * node, note status, and are from the current user.
  */
-function inope_policy_review_select_query($node, $account, $status = NULL) {
+function inope_policy_review_select_query($node, $account) {
 
   // Select query to get the latest node revision timestamp.
   $node_revision = db_query("
@@ -239,16 +239,11 @@ function inope_policy_review_select_query($node, $account, $status = NULL) {
  */
 function inope_policy_review_insert_query($node, $account, $text, $status) {
 
-  $results = inope_policy_review_select_query($node, $account, $status);
+  $results = inope_policy_review_select_query($node, $account);
 
   // If the entry already exists don't duplicate it.
-  if (!empty($results) &&
-      $results[0]->nid == $node->nid &&
-      $results[0]->vid == $node->vid &&
-      $results[0]->uid == $account->uid &&
-      $results[0]->note_status == $status &&
-      $results[0]->note == $text) {
-    drupal_set_message(t('You have previously submitted this response.'));
+  if (!empty($results)) {
+    drupal_set_message(t('You have previously submitted a response.'));
     $policy_review_id = 0;
   }
   else {

--- a/modules/custom/inope_policy_review/inope_policy_review.module
+++ b/modules/custom/inope_policy_review/inope_policy_review.module
@@ -75,10 +75,51 @@ function inope_policy_review_permission() {
 }
 
 /**
+ * Implements hook_form_alter().
+ */
+function inope_policy_review_form_alter(&$form, &$form_state, $form_id) {
+
+  global $user;
+  $account = $user;
+
+  // Store argument from the autoloader in hook_menu().
+  $node = $form_state['build_info']['args'][0];
+
+  // Check that we are only altering the inope policy review form.
+  if ($form_id == 'inope_policy_review_form') {
+
+    // Query the policy review table for any records related to the current
+    // node, unapproved notes, and are from the current user.
+    $results = db_select('policy_review', 'pr')
+      ->fields('pr')
+      ->condition('nid', $node->nid, '=')
+      ->condition('note_status', 0, '=')
+      ->condition('uid', $account->uid, '=')
+      ->execute()
+      ->fetchAssoc();
+
+    // If the active user has submitted something and is not an administrator
+    // clear the form items we don't want to show and show a message.
+    if (!empty($results) && !in_array('administrator', $account->roles)) {
+      $form['inope_policy_review_status_radio'] = array();
+      $form['inope_policy_review_changes_requested_textarea'] = array();
+      $form['inope_policy_review_submit'] = array();
+      $form['message'] = array(
+        '#type' => 'markup',
+        '#markup' => t('Thank you for your feedback!
+        Please check back often for additional review.'),
+      );
+    }
+  }
+}
+
+/**
  * The iNope Policy Review Form.
  */
 function inope_policy_review_form($form, &$form_state, $node) {
   global $user;
+
+  $account = $user;
 
   // Create radio button options (approved or changes requested).
   $status = array(
@@ -130,7 +171,7 @@ function inope_policy_review_form($form, &$form_state, $node) {
   // Store the uid for future use, not displayed to the user.
   $form['inope_policy_review_hidden_uid'] = array(
     '#type' => 'hidden',
-    '#value' => $user->uid,
+    '#value' => $account->uid,
   );
 
   // Create the submit button.
@@ -152,22 +193,57 @@ function inope_policy_review_form_submit($form, &$form_state) {
 
   // If 'I have reviewed this policy and approved it for use' is selected.
   if ($form_state['values']['inope_policy_review_status_radio'] == 0) {
-    drupal_set_message(t('Policy approved for use'));
-    // TODO: put this into the database.
+
+    // Only administrators should be able to approve notes.
+    if (in_array('administrator', $account->roles)) {
+
+      // Run an update query on the policy review table to set the note_status
+      // as approved where the fields are equal to the current node and are
+      // unapproved.
+      $updated_records = db_update('policy_review')
+        ->fields(array(
+          'note_status' => 1,
+        ))
+        ->condition('nid', $node->nid, '=')
+        ->condition('note_status', 0, '=')
+        ->execute();
+
+      drupal_set_message(t('Policy approved for use @number records updated', array(
+        '@number' => $updated_records,
+      )));
+    }
+    // Staff will receive this warning message.
+    else {
+      drupal_set_message(t('Please contact your administrator for approval.'),
+        'warning');
+    }
+
   }
   // If 'I have reviewed this policy and would like to see changes' is selected.
   elseif ($form_state['values']['inope_policy_review_status_radio'] == 1) {
+
+    // Make code more legible by setting a variable here.
+    $text = $form_state['values']['inope_policy_review_changes_requested_textarea'];
+
+    // Run an insert query on the policy review table for the new note.
+    $policy_review_id = db_insert('policy_review')
+      ->fields(array(
+        'nid' => $node->nid,
+        'vid' => $node->vid,
+        'uid' => $account->uid,
+        'note_status' => 0,
+        'note_submitted' => time(),
+        'note' => $text,
+      ))
+      ->execute();
+
+    // Thank the user for their request.
     drupal_set_message(
-      t('User : @userid : @username submitted the following change request:', array(
-        '@userid' => $account->uid,
+      t('Thank you @username for submitting the following change request:', array(
         '@username' => $account->name,
       )));
 
-    drupal_set_message($form_state['values']['inope_policy_review_changes_requested_textarea']);
-
-    drupal_set_message(t('Node ID : @nodeid', array('@nodeid' => $node->nid)));
-    drupal_set_message(t('Node VID : @nodevid', array('@nodevid' => $node->vid)));
-    // TODO: put this into the database.
+    drupal_set_message($text);
   }
   // If a bug is encountered.
   else {

--- a/modules/custom/inope_policy_review/inope_policy_review.module
+++ b/modules/custom/inope_policy_review/inope_policy_review.module
@@ -213,27 +213,22 @@ function inope_policy_review_form_submit($form, &$form_state) {
  */
 function inope_policy_review_select_query($node, $account, $status = NULL) {
 
-  // We need the ability to return all records regardless of status so we change
-  // the query based off of status = null or status = something defined.
-  if ($status == NULL) {
-    $results = db_query("
-    SELECT * FROM {policy_review} WHERE nid = :nid AND uid = :uid ORDER BY 
-    note_submitted DESC", array(
-      ':nid' => $node->nid,
-      ':uid' => $account->uid,
-    ))->fetchAll();
-  }
-  else {
-    $results = db_query("
-    SELECT * FROM {policy_review} WHERE nid = :nid AND note_status =
-    :note_status AND uid = :uid ORDER BY note_submitted DESC", array(
-      ':nid' => $node->nid,
-      ':note_status' => $status,
-      ':uid' => $account->uid,
-    ))->fetchAll();
-  }
+  // Select query to get the latest node revision timestamp.
+  $node_revision = db_query("
+  SELECT vid, timestamp FROM {node_revision} WHERE vid = :vid", array(
+    ':vid' => $node->vid,
+  ))->fetchObject();
 
-  return $results;
+  // Select query to get all records with a note_sumbitted >= vid_timestamp.
+  $policy_review_notes = db_query("
+  SELECT * FROM {policy_review} WHERE nid = :nid AND uid = :uid AND 
+  note_submitted >= :vid_timestamp ORDER BY note_submitted DESC", array(
+    ':nid' => $node->nid,
+    ':uid' => $account->uid,
+    ':vid_timestamp' => $node_revision->timestamp,
+  ))->fetchAll();
+
+  return $policy_review_notes;
 }
 
 /**

--- a/modules/custom/inope_policy_review/inope_policy_review.module
+++ b/modules/custom/inope_policy_review/inope_policy_review.module
@@ -70,10 +70,10 @@ function inope_policy_review_page($node) {
       '#markup' => t('Thank you for your feedback!
       Please check back often for additional review.'),
     );
-  } 
+  }
   else {
-    // If no results build a blank form
-    $build['inope_policy_review_form'] 
+    // If no results build a blank form.
+    $build['inope_policy_review_form']
       = drupal_get_form('inope_policy_review_form', $node);
   }
 
@@ -170,7 +170,7 @@ function inope_policy_review_form_submit($form, &$form_state) {
   $account = user_load($form_state['values']['inope_policy_review_hidden_uid']);
   $node = node_load($form_state['values']['inope_policy_review_hidden_nid']);
   $text = check_plain($form_state['values']['inope_policy_review_changes_requested_textarea']);
-  
+
   // If 'I have reviewed this policy and approved it for use' is selected.
   if ($form_state['values']['inope_policy_review_status_radio'] == 0) {
 
@@ -207,47 +207,47 @@ function inope_policy_review_form_submit($form, &$form_state) {
 
 /**
  * Select query for the current node policy review notes.
- * 
+ *
  * Query the policy review table for any records related to the current
  * node, note status, and are from the current user.
  */
 function inope_policy_review_select_query($node, $account, $status = NULL) {
-  
+
   // We need the ability to return all records regardless of status so we change
   // the query based off of status = null or status = something defined.
   if ($status == NULL) {
-    $results = db_query(
-    "SELECT * FROM {policy_review} WHERE nid = :nid AND uid = :uid ORDER BY 
-     note_submitted DESC", array(
+    $results = db_query("
+    SELECT * FROM {policy_review} WHERE nid = :nid AND uid = :uid ORDER BY 
+    note_submitted DESC", array(
       ':nid' => $node->nid,
       ':uid' => $account->uid,
     ))->fetchAll();
-  } 
+  }
   else {
-    $results = db_query(
-    "SELECT * FROM {policy_review} WHERE nid = :nid AND note_status =
-     :note_status AND uid = :uid ORDER BY note_submitted DESC", array(
+    $results = db_query("
+    SELECT * FROM {policy_review} WHERE nid = :nid AND note_status =
+    :note_status AND uid = :uid ORDER BY note_submitted DESC", array(
       ':nid' => $node->nid,
       ':note_status' => $status,
       ':uid' => $account->uid,
     ))->fetchAll();
   }
-    
+
   return $results;
 }
 
 /**
  * Insert query to add a new policy review note or approve policy.
- * 
+ *
  * Only insert the new row if it is substantially a new request meaning that
- * some value other than the timestamp is different
+ * some value other than the timestamp is different.
  */
 function inope_policy_review_insert_query($node, $account, $text, $status) {
-  
+
   $results = inope_policy_review_select_query($node, $account, $status);
-  
-  // If the entry already exists don't duplicate it
-  if (!empty($results) && 
+
+  // If the entry already exists don't duplicate it.
+  if (!empty($results) &&
       $results[0]->nid == $node->nid &&
       $results[0]->vid == $node->vid &&
       $results[0]->uid == $account->uid &&
@@ -269,18 +269,18 @@ function inope_policy_review_insert_query($node, $account, $text, $status) {
       ))
       ->execute();
   }
-  
+
   return $policy_review_id;
 }
 
 /**
  * Update query if the user wants to update a record.
- * 
- * Currently this funtion is not called anywhere but it is avaliable for future 
+ *
+ * Currently this funtion is not called anywhere but it is avaliable for future
  * use.
  */
 function inope_policy_review_update_query($node, $account, $text, $timestamp) {
-  
+
   // Run an update query on the policy review table to change the note.
   $updated_records = db_update('policy_review')
     ->fields(array(
@@ -290,6 +290,6 @@ function inope_policy_review_update_query($node, $account, $text, $timestamp) {
     ->condition('uid', $account->uid, '=')
     ->condition('note_submitted', $timestamp, '=')
     ->execute();
-  
+
   return $updated_records;
 }

--- a/modules/custom/inope_policy_review/inope_policy_review.module
+++ b/modules/custom/inope_policy_review/inope_policy_review.module
@@ -16,7 +16,8 @@ function inope_policy_review_menu() {
     'description' => 'Review of policy nodes.',
     'page callback' => 'inope_policy_review_page',
     'page arguments' => array(1),
-    'access arguments' => array('view inope policy review'),
+    'access callback' => 'inope_policy_review_access_callback',
+    'access arguments' => array(1, 'view inope policy review'),
     'type' => MENU_LOCAL_TASK,
   );
 
@@ -40,6 +41,37 @@ function inope_policy_review_tab_title_callback($node) {
   // Create the string to be used as the tab title.
   $title = t('Review of @node_title', array('@node_title' => $node->title));
   return $title;
+}
+
+/**
+ * Check access for the policy review tab also choose when to display.
+ *
+ * @param object $node
+ *   Object representing the current node passed from hook_menu.
+ *
+ * @param string $permission
+ *   String representing the allowed permission passed from hook_menu.
+ * 
+ * @return boolean
+ *   Boolean (TRUE or FALSE) representing access to the policy review page.
+ */
+function inope_policy_review_access_callback($node, $permission) {
+  
+  // Check that we are only adding the tab to the inope policy node type.
+  // This check must happen first as when we return false the rest of the
+  // function does not continue to execute.
+  if ($node->type != 'inope_policy') {
+    return FALSE;
+  }
+  
+  // Check that we have the permission 'view inope policy review' set in
+  // hook_menu().
+  if (user_access($permission)) {
+    return TRUE;
+  }
+  
+  // If neither of the first were true default to access denied.
+  return FALSE;
 }
 
 /**
@@ -213,19 +245,13 @@ function inope_policy_review_form_submit($form, &$form_state) {
  */
 function inope_policy_review_select_query($node, $account) {
 
-  // Select query to get the latest node revision timestamp.
-  $node_revision = db_query("
-  SELECT vid, timestamp FROM {node_revision} WHERE vid = :vid", array(
-    ':vid' => $node->vid,
-  ))->fetchObject();
-
-  // Select query to get all records with a note_sumbitted >= vid_timestamp.
+  // Select query to get all records with a note_sumbitted >= node->changed.
   $policy_review_notes = db_query("
   SELECT * FROM {policy_review} WHERE nid = :nid AND uid = :uid AND 
-  note_submitted >= :vid_timestamp ORDER BY note_submitted DESC", array(
+  note_submitted >= :timestamp ORDER BY note_submitted DESC", array(
     ':nid' => $node->nid,
     ':uid' => $account->uid,
-    ':vid_timestamp' => $node_revision->timestamp,
+    ':timestamp' => $node->changed,
   ))->fetchAll();
 
   return $policy_review_notes;

--- a/modules/custom/inope_policy_review/inope_policy_review.module
+++ b/modules/custom/inope_policy_review/inope_policy_review.module
@@ -48,28 +48,27 @@ function inope_policy_review_tab_title_callback($node) {
  *
  * @param object $node
  *   Object representing the current node passed from hook_menu.
- *
  * @param string $permission
  *   String representing the allowed permission passed from hook_menu.
- * 
- * @return boolean
+ *
+ * @return bool
  *   Boolean (TRUE or FALSE) representing access to the policy review page.
  */
 function inope_policy_review_access_callback($node, $permission) {
-  
+
   // Check that we are only adding the tab to the inope policy node type.
   // This check must happen first as when we return false the rest of the
   // function does not continue to execute.
   if ($node->type != 'inope_policy') {
     return FALSE;
   }
-  
+
   // Check that we have the permission 'view inope policy review' set in
   // hook_menu().
   if (user_access($permission)) {
     return TRUE;
   }
-  
+
   // If neither of the first were true default to access denied.
   return FALSE;
 }

--- a/modules/features/feature_inope_policy/feature_inope_policy.strongarm.inc
+++ b/modules/features/feature_inope_policy/feature_inope_policy.strongarm.inc
@@ -82,6 +82,7 @@ function feature_inope_policy_strongarm() {
   $strongarm->value = array(
     0 => 'status',
     1 => 'promote',
+    2 => 'revision',
   );
   $export['node_options_inope_policy'] = $strongarm;
 


### PR DESCRIPTION
## This PR makes a couple of changes:
- It creates a table named policy_review to store our form information in
- It sends an insert query during the form submission to record our data
- It sends select queries to check for existing data
## Steps to test your new table in the database:
- Follow the instructions from pull request 1 for a fresh install
- Verify that the inope_policy_review module was enabled (and installed)
- Check your database for a new table named policy_review with columns:
  - policy_review_id (primary key)
  - vid
  - nid
  - uid
  - note_status
  - note_submitted
  - note
- Go to /upgrade.php for existing websites (verify that you have update 7100 to perform)
- Check your database for a new table named policy_review with columns mentioned above
- NOTE: If you are uninstalling the module to test this make sure you uninstall feature_inope_policy also

If your vm is named inope and you are using drupal vm then you can:

Copy and paste to uninstall necessary modules:

```
drush @drupalvm.inope.drupalvm.dev dis feature_inope_policy -y; drush @drupalvm.inope.drupalvm.dev dis inope_policy_review -y; drush @drupalvm.inope.drupalvm.dev pmu feature_inope_policy -y; drush @drupalvm.inope.drupalvm.dev pmu inope_policy_review -y;
```

Copy and paste to reinstall necessary modules:

```
drush @drupalvm.inope.drupalvm.dev en feature_inope_policy -y; drush @drupalvm.inope.drupalvm.dev en inope_policy_review -y;
```
## Steps to test functionality - Setup:
- Create two users (admin and staff)
- Log in as admin
- Create a node of the policy type (employee handbook or vacation policy)
## Steps to test functionality - Per User
- View the new node, then click on the "Review of {node_title}" tab
- Submit approved status
- Verify that you don't see the form anymore and see a message thanking you for your input
- Once this is verified open Sequel Pro and truncate the table
  - This is so we can submit input again as the same user
- Submit a changes requested status with some text describing you desired change
- Verify that you don't see the form anymore and see a message thanking you for your input
- Repeat these steps for the staff user
## Question:
- My current understanding is that although I declared the foreign keys in the hook_schema() they are not actually used in MySQL.  I read somewhere that Drupal doesn't take advantage of this yet and it is more of a documentation thing than a functional thing.  Is this still the case or is my information outdated?
