### PR TITLE
Challenge4 - Administrative interface

### DIFF
--- a/modules/custom/inope_policy_review/inope_policy_review.install
+++ b/modules/custom/inope_policy_review/inope_policy_review.install
@@ -104,3 +104,10 @@ function inope_policy_review_update_7101() {
       ->execute();
   }
 }
+
+/**
+ * Revert feature_inope_policy for new permission.
+ */
+function inope_policy_review_update_7102() {
+  features_revert_module('feature_inope_policy');
+}

--- a/modules/custom/inope_policy_review/inope_policy_review.install
+++ b/modules/custom/inope_policy_review/inope_policy_review.install
@@ -59,8 +59,8 @@ function inope_policy_review_schema() {
     'indexes' => array(
       'note_active' => array(
         'nid',
-        'note_status',
         'uid',
+        'note_submitted',
       ),
     ),
     'foreign keys' => array(

--- a/modules/custom/inope_policy_review/inope_policy_review.install
+++ b/modules/custom/inope_policy_review/inope_policy_review.install
@@ -91,3 +91,16 @@ function inope_policy_review_update_7100() {
     drupal_install_schema('inope_policy_review');
   }
 }
+
+/**
+ * Update the database policy_review table note_status field boolean value.
+ */
+function inope_policy_review_update_7101() {
+  // To make the note_status field match the status radio button value we need
+  // to switch the boolean value.
+  if (db_table_exists('policy_review') == TRUE) {
+    db_update('policy_review')
+      ->expression('note_status', 'NOT note_status')
+      ->execute();
+  }
+}

--- a/modules/custom/inope_policy_review/inope_policy_review.install
+++ b/modules/custom/inope_policy_review/inope_policy_review.install
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the inope_policy_review module.
+ */
+
+/**
+ * Implements hook_schema().
+ */
+function inope_policy_review_schema() {
+  $schema['policy_review'] = array(
+    'description' => 'The table for policy reviews.',
+    'fields' => array(
+      'policy_review_id' => array(
+        'description' => 'The primary identifier for a policy review note.',
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ),
+      'vid' => array(
+        'description' => 'The current node vid.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => FALSE,
+      ),
+      'nid' => array(
+        'description' => 'The current node nid.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => FALSE,
+      ),
+      'uid' => array(
+        'description' => 'The current user uid.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => FALSE,
+      ),
+      'note_status' => array(
+        'description' => 'Boolean indicating the note status.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'note_submitted' => array(
+        'description' => 'The Unix timestamp when the note was submitted.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'note' => array(
+        'description' => 'A brief policy review note.',
+        'type' => 'text',
+        'not null' => TRUE,
+        'size' => 'medium',
+        'translatable' => TRUE,
+      ),
+    ),
+    'indexes' => array(
+      'note_active' => array(
+        'nid',
+        'note_status',
+        'uid',
+      ),
+    ),
+    'foreign keys' => array(
+      'node' => array(
+        'table' => 'node',
+        'columns' => array('nid' => 'nid'),
+      ),
+      'users' => array(
+        'table' => 'users',
+        'columns' => array('uid' => 'uid'),
+      ),
+    ),
+    'primary key' => array('policy_review_id'),
+  );
+  return $schema;
+}
+
+/**
+ * Install the schema.
+ *
+ * Note that we only need to do this while upgrading as drupal_install_schema
+ * is called by default in hook_install().
+ */
+function inope_policy_review_update_7000() {
+  // Install the schema if the table does not exist.  This prevents the install
+  // hook from running twice.
+  if (db_table_exists('policy_review') == FALSE) {
+    drupal_install_schema('inope_policy_review');
+  }
+}

--- a/modules/custom/inope_policy_review/inope_policy_review.install
+++ b/modules/custom/inope_policy_review/inope_policy_review.install
@@ -84,7 +84,7 @@ function inope_policy_review_schema() {
  * Note that we only need to do this while upgrading as drupal_install_schema
  * is called by default in hook_install().
  */
-function inope_policy_review_update_7000() {
+function inope_policy_review_update_7100() {
   // Install the schema if the table does not exist.  This prevents the install
   // hook from running twice.
   if (db_table_exists('policy_review') == FALSE) {

--- a/modules/custom/inope_policy_review/inope_policy_review.module
+++ b/modules/custom/inope_policy_review/inope_policy_review.module
@@ -37,8 +37,30 @@ function inope_policy_review_menu() {
  *   policy nodes.
  */
 function inope_policy_review_tab_title_callback($node) {
+
+  global $user;
+  $account = $user;
+
   // Create the string to be used as the tab title.
   $title = t('Review of @node_title', array('@node_title' => $node->title));
+
+  // Retreive all notes related to this node, account, and vid_timestamp.
+  $results = inope_policy_review_select_query_all($node, $account);
+  $node_revision = inope_policy_review_select_query_timestamp($node);
+
+  // Change the title based off last submission.
+  if (empty($results)) {
+    $title .= ' (NEW)';
+    drupal_set_message(t('This is a new policy, please provide feedback.'), 'status', $repeat = FALSE);
+  }
+  elseif ($results[0]->note_submitted < $node_revision->timestamp) {
+    $title .= ' (UPDATED)';
+    drupal_set_message(t('This policy has been updated, please provide feedback.'), 'status', $repeat = FALSE);
+  }
+  else {
+    // Return the normal title without changes.
+  }
+
   return $title;
 }
 
@@ -58,23 +80,48 @@ function inope_policy_review_page($node) {
   global $user;
   $account = $user;
   $build = array();
+  $policy_review_id = NULL;
+
+  // Get the parameters passed in the url and if possible set policy_review_id.
+  $get_params = drupal_get_query_parameters();
+  if (!empty($get_params['id'])) {
+    $policy_review_id = $get_params['id'];
+  }
 
   // Retreive all notes related to this node and account.
   $results = inope_policy_review_select_query($node, $account);
 
   // If the active user has previously submitted something only display a
   // message.
-  if (!empty($results)) {
+  if (empty($results)) {
+    // If no results build a blank form.
+    $build['inope_policy_review_form']
+      = drupal_get_form('inope_policy_review_form', $node);
+  }
+  elseif ($policy_review_id == NULL) {
+    // If results and no id requested show message and table of results.
     $build['message'] = array(
       '#type' => 'markup',
       '#markup' => t('Thank you for your feedback!
       Please check back often for additional review.'),
     );
+    $build['table'] = array(
+      '#type' => 'markup',
+      '#markup' => inope_policy_review_table($node, $account),
+    );
+  }
+  elseif (!empty($policy_review_id)) {
+    // Build a form with the requested policy_review_id.
+    $build['inope_policy_review_form']
+      = drupal_get_form('inope_policy_review_form', $node, $policy_review_id);
   }
   else {
-    // If no results build a blank form.
-    $build['inope_policy_review_form']
-      = drupal_get_form('inope_policy_review_form', $node);
+    // Page state not recognized.
+    $build['message'] = array(
+      '#type' => 'markup',
+      '#markup' => t('There seems to be a problem please contact your site
+        administrator.'),
+    );
   }
 
   return $build;
@@ -95,10 +142,30 @@ function inope_policy_review_permission() {
 /**
  * The iNope Policy Review Form.
  */
-function inope_policy_review_form($form, &$form_state, $node) {
+function inope_policy_review_form($form, &$form_state, $node, $policy_review_id = NULL) {
+  // Set active account.
   global $user;
-
   $account = $user;
+
+  // Set default values.
+  $status_radio_default_value = 0;
+  $changes_requested_textarea_default_value = '';
+  $policy_review_id_default_value = NULL;
+
+  // Override default values $primary_key is set.
+  if (!empty($policy_review_id)) {
+    $policy_review_note = inope_policy_review_select_query_one($policy_review_id);
+
+    // Check user access then set default form values to old note values.
+    if ($account->uid == $policy_review_note->uid) {
+      $status_radio_default_value = $policy_review_note->note_status;
+      $changes_requested_textarea_default_value = $policy_review_note->note;
+      $policy_review_id_default_value = $policy_review_note->policy_review_id;
+    }
+    else {
+      drupal_goto('node/' . $node->nid . '/review');
+    }
+  }
 
   // Create radio button options (approved or changes requested).
   $status = array(
@@ -110,7 +177,7 @@ function inope_policy_review_form($form, &$form_state, $node) {
   $form['inope_policy_review_status_radio'] = array(
     '#type' => 'radios',
     '#options' => $status,
-    '#default_value' => 0,
+    '#default_value' => $status_radio_default_value,
   );
 
   // Create text area for feedback on changes requested option only.
@@ -118,7 +185,7 @@ function inope_policy_review_form($form, &$form_state, $node) {
   $form['inope_policy_review_changes_requested_textarea'] = array(
     '#type' => 'textarea',
     '#title' => t('Changes Requested:'),
-    '#default_value' => '',
+    '#default_value' => $changes_requested_textarea_default_value,
     '#states' => array(
       'invisible' => array(
         ':input[name="inope_policy_review_status_radio"]' => array('value' => 0),
@@ -132,8 +199,11 @@ function inope_policy_review_form($form, &$form_state, $node) {
     ),
   );
 
-  // Store argument from the autoloader in hook_menu().
-  $node = $form_state['build_info']['args'][0];
+  // Store the policy_review_id for future use, not displayed to the user.
+  $form['inope_policy_review_hidden_policy_review_id'] = array(
+    '#type' => 'hidden',
+    '#value' => $policy_review_id_default_value,
+  );
 
   // Store the nid for future use, not displayed to the user.
   $form['inope_policy_review_hidden_nid'] = array(
@@ -164,45 +234,94 @@ function inope_policy_review_form($form, &$form_state, $node) {
 
 /**
  * The iNope Policy Review Form submit handler.
+ *
+ * This submit handler is broken up into 5 parts.
+ * PART 1 - Set variables and load necessary objects.
+ * PART 2 - Update existing entries if policy review id is a non empty string.
+ * PART 3 - Insert an approved response.
+ * PART 4 - Insert a changes requested response.
+ * PART 5 - Catch errors.
  */
 function inope_policy_review_form_submit($form, &$form_state) {
-  // Load objects from which their properties will be displayed.
+  // PART 1 - Load objects from which their properties will be displayed.
   $account = user_load($form_state['values']['inope_policy_review_hidden_uid']);
   $node = node_load($form_state['values']['inope_policy_review_hidden_nid']);
   $text = check_plain($form_state['values']['inope_policy_review_changes_requested_textarea']);
 
-  // If 'I have reviewed this policy and approved it for use' is selected.
-  if ($form_state['values']['inope_policy_review_status_radio'] == 0) {
+  // PART 2 - Check to see if we are updating an existing entry by checking if
+  // the form value hidden_policy_review_id is set to a non empty string.
+  if ($form_state['values']['inope_policy_review_hidden_policy_review_id'] != '') {
 
-    $policy_review_id = inope_policy_review_insert_query($node, $account, '', 1);
+    // Run the update query using form_state values.
+    inope_policy_review_update_query($form_state);
 
-    if ($policy_review_id != 0) {
-      // Thank the user for their approval.
-      drupal_set_message(
-        t('Thank you @username for approving the policy', array(
-          '@username' => $account->name,
-        )));
-    }
+    // Clear previous messages and thank the user for their update.
+    drupal_get_messages();
+    drupal_set_message(
+      t('Thank you @username for your update to the policy', array(
+        '@username' => $account->name,
+      )));
+
+    // Send the user back to the main review page for the node.
+    drupal_goto('node/' . $node->nid . '/review');
+
   }
-  // If 'I have reviewed this policy and would like to see changes' is selected.
-  elseif ($form_state['values']['inope_policy_review_status_radio'] == 1) {
-
-    $policy_review_id = inope_policy_review_insert_query($node, $account, $text, 0);
-
-    if ($policy_review_id != 0) {
-      // Thank the user for their request.
-      drupal_set_message(
-        t('Thank you @username for submitting the following change request:', array(
-          '@username' => $account->name,
-        )));
-      // Check_plain happened when this variable was declared.
-      drupal_set_message($text);
-    }
-  }
-  // If a bug is encountered.
   else {
-    drupal_set_message(t('Form state not recognized'));
+    // PART 3 - If 'I have reviewed this policy and approved it for use' is
+    // selected then insert values into the database.
+    if ($form_state['values']['inope_policy_review_status_radio'] == 0) {
+
+      $policy_review_id = inope_policy_review_insert_query($node, $account, '', 0);
+
+      if ($policy_review_id != 0) {
+
+        // Clear previous messages and thank the user for their approval.
+        drupal_get_messages();
+        drupal_set_message(
+          t('Thank you @username for approving the policy', array(
+            '@username' => $account->name,
+          )));
+      }
+    }
+    // PART 4 - If 'I have reviewed this policy and would like to see changes'
+    // is selected then insert values into the database.
+    elseif ($form_state['values']['inope_policy_review_status_radio'] == 1) {
+
+      $policy_review_id = inope_policy_review_insert_query($node, $account, $text, 1);
+
+      if ($policy_review_id != 0) {
+
+        // Clear previous messages and thank the user for their request.
+        drupal_get_messages();
+        drupal_set_message(
+          t('Thank you @username for submitting the following change request:', array(
+            '@username' => $account->name,
+          )));
+
+        // Check_plain happened when this variable was declared.
+        drupal_set_message($text);
+      }
+    }
+    // PART 5 - Catch errors.
+    else {
+      drupal_set_message(t('Form state not recognized, please contact your
+        administrator'));
+    }
   }
+}
+
+/**
+ * Select query for the current node revision timestamp.
+ */
+function inope_policy_review_select_query_timestamp($node) {
+
+  // Select query to get the latest node revision timestamp.
+  $node_revision = db_query("
+  SELECT vid, timestamp FROM {node_revision} WHERE vid = :vid", array(
+    ':vid' => $node->vid,
+  ))->fetchObject();
+
+  return $node_revision;
 }
 
 /**
@@ -214,10 +333,7 @@ function inope_policy_review_form_submit($form, &$form_state) {
 function inope_policy_review_select_query($node, $account) {
 
   // Select query to get the latest node revision timestamp.
-  $node_revision = db_query("
-  SELECT vid, timestamp FROM {node_revision} WHERE vid = :vid", array(
-    ':vid' => $node->vid,
-  ))->fetchObject();
+  $node_revision = inope_policy_review_select_query_timestamp($node);
 
   // Select query to get all records with a note_sumbitted >= vid_timestamp.
   $policy_review_notes = db_query("
@@ -229,6 +345,39 @@ function inope_policy_review_select_query($node, $account) {
   ))->fetchAll();
 
   return $policy_review_notes;
+}
+
+/**
+ * Select query for the current node policy review notes.
+ *
+ * Query the policy review table for ALL records related to the current
+ * node and are from the current user REGARDLESS of vid timestamp or status.
+ */
+function inope_policy_review_select_query_all($node, $account) {
+
+  // Select query to get all records with a note_sumbitted >= vid_timestamp.
+  $policy_review_notes = db_query("
+  SELECT * FROM {policy_review} WHERE nid = :nid AND uid = :uid ORDER BY 
+  note_submitted DESC", array(
+    ':nid' => $node->nid,
+    ':uid' => $account->uid,
+  ))->fetchAll();
+
+  return $policy_review_notes;
+}
+
+/**
+ * Select query for the a single policy review note.
+ */
+function inope_policy_review_select_query_one($policy_review_id) {
+
+  // Select query to get a single record based on the primary key.
+  $policy_review_note = db_query("
+  SELECT * FROM {policy_review} WHERE policy_review_id = :policy_review_id", array(
+    ':policy_review_id' => $policy_review_id,
+  ))->fetchObject();
+
+  return $policy_review_note;
 }
 
 /**
@@ -269,17 +418,101 @@ function inope_policy_review_insert_query($node, $account, $text, $status) {
  * Currently this funtion is not called anywhere but it is avaliable for future
  * use.
  */
-function inope_policy_review_update_query($node, $account, $text, $timestamp) {
+function inope_policy_review_update_query(&$form_state) {
+  global $user;
+  $account = $user;
+
+  $note_status = $form_state['values']['inope_policy_review_status_radio'];
+
+  // If the user changed note status to approved, remove the old change request.
+  if ($form_state['values']['inope_policy_review_status_radio'] == 0) {
+    $form_state['values']['inope_policy_review_changes_requested_textarea'] = '';
+  }
 
   // Run an update query on the policy review table to change the note.
   $updated_records = db_update('policy_review')
     ->fields(array(
-      'note' => $text,
+      'note_status' => $note_status,
+      'note' => $form_state['values']['inope_policy_review_changes_requested_textarea'],
     ))
-    ->condition('nid', $node->nid, '=')
-    ->condition('uid', $account->uid, '=')
-    ->condition('note_submitted', $timestamp, '=')
+    ->condition('policy_review_id', $form_state['values']['inope_policy_review_hidden_policy_review_id'], '=')
     ->execute();
 
   return $updated_records;
+}
+
+/**
+ * Build a table to display the data for the current node.
+ */
+function inope_policy_review_table($node, $account) {
+  // Set table headers.
+  $header = array(
+    'Policy Review ID' => array(
+      'data' => t('Policy Review ID'),
+      'field' => 'policy_review_id',
+    ),
+    'Version' => array(
+      'data' => t('Version'),
+      'field' => 'vid',
+    ),
+    'Date' => array(
+      'data' => t('Date'),
+      'field' => 'note_submitted',
+      'sort' => 'desc',
+    ),
+    'Request Status' => array(
+      'data' => t('Request Status'),
+      'field' => 'note_status',
+    ),
+    'Note' => array(
+      'data' => t('Note'),
+      'field' => 'note',
+    ),
+    '',
+  );
+
+  // Create $rows variable.
+  $rows = array();
+
+  // Change note status from a binary number to text for display to the user.
+  $note_status_text = array('Approved', 'Change Requested');
+
+  // Build a dynamic 'TableSort' query that uses the GET parameters to order the
+  // table.  The TableSort is key, without it you need another way to change
+  // your query based on the GET parameters passed.
+  $query = db_select('policy_review', 'pr')
+    ->fields('pr')
+    ->condition('uid', $account->uid, '=')
+    ->condition('nid', $node->nid, '=')
+    ->extend('TableSort')
+    ->orderByHeader($header);
+
+  // Execute the query and store the results in a variable.
+  $results = $query->execute();
+
+  // Process the results.
+  foreach ($results as $result) {
+    $rows[] = array(
+      array(
+        'data' => l($result->policy_review_id,
+                    'node/' . $node->nid . '/review',
+                    array('query' => array('id' => $result->policy_review_id))),
+      ),
+      array('data' => $result->vid),
+      array('data' => format_date($result->note_submitted, 'short')),
+      array('data' => $note_status_text[$result->note_status]),
+      array('data' => $result->note),
+      array(
+        'data' => l(t('Edit'),
+                    'node/' . $node->nid . '/review',
+                    array('query' => array('id' => $result->policy_review_id))),
+      ),
+    );
+  }
+
+  // Have the theme_table() function build your new table.
+  return theme('table', array(
+    'header' => $header,
+    'rows' => $rows,
+  ));
 }

--- a/modules/custom/inope_policy_review/inope_policy_review.module
+++ b/modules/custom/inope_policy_review/inope_policy_review.module
@@ -120,14 +120,32 @@ function inope_policy_review_page($node) {
   // Retreive all notes related to this node and account.
   $results = inope_policy_review_select_query($node, $account);
 
-  // If the active user has previously submitted something only display a
-  // message.
-  if (empty($results)) {
-    // If no results build a blank form.
+  // If the active user does NOT have administrator role and has NOT previously
+  // submitted something.
+  if (empty($results) && !user_access('administer inope policy review')) {
+    // Build a blank form.
     $build['inope_policy_review_form']
       = drupal_get_form('inope_policy_review_form', $node);
   }
+  // If the active user does HAVE the administrator role and has NOT previously
+  // submitted something.
+  elseif (empty($results) && user_access('administer inope policy review')) {
+
+    // Build a blank form AND dislay notes from other users.
+    $build['inope_policy_review_form']
+      = drupal_get_form('inope_policy_review_form', $node);
+
+    // Build a table of results from other users.
+    $build['table'] = array(
+      '#type' => 'markup',
+      '#markup' => inope_policy_review_table($node, $account),
+    );
+  }
+  // Now we must have results so no need to check for it.
+  // We now check if the URL contains GET parameters for a specific policy
+  // review note starting with the NOT set state.
   elseif ($policy_review_id == NULL) {
+
     // If results and no id requested show message and table of results.
     $build['message'] = array(
       '#type' => 'markup',
@@ -139,12 +157,15 @@ function inope_policy_review_page($node) {
       '#markup' => inope_policy_review_table($node, $account),
     );
   }
+  // Now if policy review id IS set then build a form with that information.
   elseif (!empty($policy_review_id)) {
+
     // Build a form with the requested policy_review_id.
     $build['inope_policy_review_form']
       = drupal_get_form('inope_policy_review_form', $node, $policy_review_id);
   }
   else {
+
     // Page state not recognized.
     $build['message'] = array(
       '#type' => 'markup',

--- a/modules/custom/inope_policy_review/inope_policy_review.module
+++ b/modules/custom/inope_policy_review/inope_policy_review.module
@@ -55,10 +55,31 @@ function inope_policy_review_tab_title_callback($node) {
  *   policy nodes.
  */
 function inope_policy_review_page($node) {
-  // Create a build array to be displayed on the page.
-  $build = array(
-    'inope_policy_review_form' => drupal_get_form('inope_policy_review_form', $node),
-  );
+  global $user;
+  $account = $user;
+  $build = array();
+
+  // TODO: Ask client if they want previously submitted approval to be allowed
+  // to be overwritten, this is the current functionality.
+  $results = inope_policy_review_select_query($node, $account, 0);
+
+  // TODO: When the form is rebuilt query above this doesn't pick up the new
+  // entry.
+  // If the active user has previously submitted something only display a
+  // message.
+  if (!empty($results)) {
+    $build['message'] = array(
+      '#type' => 'markup',
+      '#markup' => t('Thank you for your feedback!
+      Please check back often for additional review.'),
+    );
+  } 
+  else {
+    // If no results build a blank form
+    $build['inope_policy_review_form'] 
+      = drupal_get_form('inope_policy_review_form', $node);
+  }
+
   return $build;
 }
 
@@ -72,45 +93,6 @@ function inope_policy_review_permission() {
       'description' => t('View the review tab on policy node pages'),
     ),
   );
-}
-
-/**
- * Implements hook_form_alter().
- */
-function inope_policy_review_form_alter(&$form, &$form_state, $form_id) {
-
-  global $user;
-  $account = $user;
-
-  // Store argument from the autoloader in hook_menu().
-  $node = $form_state['build_info']['args'][0];
-
-  // Check that we are only altering the inope policy review form.
-  if ($form_id == 'inope_policy_review_form') {
-
-    // Query the policy review table for any records related to the current
-    // node, unapproved notes, and are from the current user.
-    $results = db_select('policy_review', 'pr')
-      ->fields('pr')
-      ->condition('nid', $node->nid, '=')
-      ->condition('note_status', 0, '=')
-      ->condition('uid', $account->uid, '=')
-      ->execute()
-      ->fetchAssoc();
-
-    // If the active user has submitted something and is not an administrator
-    // clear the form items we don't want to show and show a message.
-    if (!empty($results) && !in_array('administrator', $account->roles)) {
-      $form['inope_policy_review_status_radio'] = array();
-      $form['inope_policy_review_changes_requested_textarea'] = array();
-      $form['inope_policy_review_submit'] = array();
-      $form['message'] = array(
-        '#type' => 'markup',
-        '#markup' => t('Thank you for your feedback!
-        Please check back often for additional review.'),
-      );
-    }
-  }
 }
 
 /**
@@ -190,60 +172,35 @@ function inope_policy_review_form_submit($form, &$form_state) {
   // Load objects from which their properties will be displayed.
   $account = user_load($form_state['values']['inope_policy_review_hidden_uid']);
   $node = node_load($form_state['values']['inope_policy_review_hidden_nid']);
-
+  $text = check_plain($form_state['values']['inope_policy_review_changes_requested_textarea']);
+  
   // If 'I have reviewed this policy and approved it for use' is selected.
   if ($form_state['values']['inope_policy_review_status_radio'] == 0) {
 
-    // Only administrators should be able to approve notes.
-    if (in_array('administrator', $account->roles)) {
+    $policy_review_id = inope_policy_review_insert_query($node, $account, '', 1);
 
-      // Run an update query on the policy review table to set the note_status
-      // as approved where the fields are equal to the current node and are
-      // unapproved.
-      $updated_records = db_update('policy_review')
-        ->fields(array(
-          'note_status' => 1,
-        ))
-        ->condition('nid', $node->nid, '=')
-        ->condition('note_status', 0, '=')
-        ->execute();
-
-      drupal_set_message(t('Policy approved for use @number records updated', array(
-        '@number' => $updated_records,
-      )));
+    if ($policy_review_id != 0) {
+      // Thank the user for their approval.
+      drupal_set_message(
+        t('Thank you @username for approving the policy', array(
+          '@username' => $account->name,
+        )));
     }
-    // Staff will receive this warning message.
-    else {
-      drupal_set_message(t('Please contact your administrator for approval.'),
-        'warning');
-    }
-
   }
   // If 'I have reviewed this policy and would like to see changes' is selected.
   elseif ($form_state['values']['inope_policy_review_status_radio'] == 1) {
 
-    // Make code more legible by setting a variable here.
-    $text = $form_state['values']['inope_policy_review_changes_requested_textarea'];
+    $policy_review_id = inope_policy_review_insert_query($node, $account, $text, 0);
 
-    // Run an insert query on the policy review table for the new note.
-    $policy_review_id = db_insert('policy_review')
-      ->fields(array(
-        'nid' => $node->nid,
-        'vid' => $node->vid,
-        'uid' => $account->uid,
-        'note_status' => 0,
-        'note_submitted' => time(),
-        'note' => $text,
-      ))
-      ->execute();
-
-    // Thank the user for their request.
-    drupal_set_message(
-      t('Thank you @username for submitting the following change request:', array(
-        '@username' => $account->name,
-      )));
-
-    drupal_set_message($text);
+    if ($policy_review_id != 0) {
+      // Thank the user for their request.
+      drupal_set_message(
+        t('Thank you @username for submitting the following change request:', array(
+          '@username' => $account->name,
+        )));
+      // Check_plain happened when this variable was declared.
+      drupal_set_message($text);
+    }
   }
   // If a bug is encountered.
   else {
@@ -252,4 +209,81 @@ function inope_policy_review_form_submit($form, &$form_state) {
 
   // Rebuild the form.
   $form_state['rebuild'] = TRUE;
+}
+
+/**
+ * Select query for the current node policy review notes.
+ * 
+ * Query the policy review table for any records related to the current
+ * node, note status, and are from the current user.
+ */
+function inope_policy_review_select_query($node, $account, $status) {
+  
+  $results = db_query(
+    "SELECT * FROM {policy_review} WHERE nid = :nid AND note_status =
+     :note_status AND uid = :uid ORDER BY note_submitted DESC", array(
+      ':nid' => $node->nid,
+      ':note_status' => $status,
+      ':uid' => $account->uid,
+    ))->fetchAll();
+  
+  return $results;
+}
+
+/**
+ * Insert query to add a new policy review note or approve policy.
+ * 
+ * Only insert the new row if it is substantially a new request meaning that
+ * some value other than the timestamp is different
+ */
+function inope_policy_review_insert_query($node, $account, $text, $status) {
+  
+  $results = inope_policy_review_select_query($node, $account, $status);
+  
+  // If the entry already exists don't duplicate it
+  if (!empty($results) && 
+      $results[0]->nid == $node->nid &&
+      $results[0]->vid == $node->vid &&
+      $results[0]->uid == $account->uid &&
+      $results[0]->note_status == $status &&
+      $results[0]->note == $text) {
+    drupal_set_message(t('You have previously submitted this response.'));
+    $policy_review_id = 0;
+  }
+  else {
+    // Run an insert query on the policy review table for the new note.
+    $policy_review_id = db_insert('policy_review')
+      ->fields(array(
+        'nid' => $node->nid,
+        'vid' => $node->vid,
+        'uid' => $account->uid,
+        'note_status' => $status,
+        'note_submitted' => time(),
+        'note' => $text,
+      ))
+      ->execute();
+  }
+  
+  return $policy_review_id;
+}
+
+/**
+ * Update query if the user wants to update a record.
+ * 
+ * Currently this funtion is not called anywhere but it is avaliable for future 
+ * use.
+ */
+function inope_policy_review_update_query($node, $account, $text, $timestamp) {
+  
+  // Run an update query on the policy review table to change the note.
+  $updated_records = db_update('policy_review')
+    ->fields(array(
+      'note' => $text,
+    ))
+    ->condition('nid', $node->nid, '=')
+    ->condition('uid', $account->uid, '=')
+    ->condition('note_submitted', $timestamp, '=')
+    ->execute();
+  
+  return $updated_records;
 }

--- a/modules/custom/inope_policy_review/inope_policy_review.module
+++ b/modules/custom/inope_policy_review/inope_policy_review.module
@@ -59,12 +59,9 @@ function inope_policy_review_page($node) {
   $account = $user;
   $build = array();
 
-  // TODO: Ask client if they want previously submitted approval to be allowed
-  // to be overwritten, this is the current functionality.
-  $results = inope_policy_review_select_query($node, $account, 0);
+  // Retreive all notes related to this node and account.
+  $results = inope_policy_review_select_query($node, $account);
 
-  // TODO: When the form is rebuilt query above this doesn't pick up the new
-  // entry.
   // If the active user has previously submitted something only display a
   // message.
   if (!empty($results)) {
@@ -206,9 +203,6 @@ function inope_policy_review_form_submit($form, &$form_state) {
   else {
     drupal_set_message(t('Form state not recognized'));
   }
-
-  // Rebuild the form.
-  $form_state['rebuild'] = TRUE;
 }
 
 /**
@@ -217,16 +211,28 @@ function inope_policy_review_form_submit($form, &$form_state) {
  * Query the policy review table for any records related to the current
  * node, note status, and are from the current user.
  */
-function inope_policy_review_select_query($node, $account, $status) {
+function inope_policy_review_select_query($node, $account, $status = NULL) {
   
-  $results = db_query(
+  // We need the ability to return all records regardless of status so we change
+  // the query based off of status = null or status = something defined.
+  if ($status == NULL) {
+    $results = db_query(
+    "SELECT * FROM {policy_review} WHERE nid = :nid AND uid = :uid ORDER BY 
+     note_submitted DESC", array(
+      ':nid' => $node->nid,
+      ':uid' => $account->uid,
+    ))->fetchAll();
+  } 
+  else {
+    $results = db_query(
     "SELECT * FROM {policy_review} WHERE nid = :nid AND note_status =
      :note_status AND uid = :uid ORDER BY note_submitted DESC", array(
       ':nid' => $node->nid,
       ':note_status' => $status,
       ':uid' => $account->uid,
     ))->fetchAll();
-  
+  }
+    
   return $results;
 }
 

--- a/modules/custom/inope_policy_review/inope_policy_review.module
+++ b/modules/custom/inope_policy_review/inope_policy_review.module
@@ -497,9 +497,6 @@ function inope_policy_review_table($node, $account, $report_page = FALSE) {
       'data' => t('Note'),
       'field' => 'pr.note',
     ),
-    'Edit' => array(
-      'data' => '',
-    ),
   );
 
   // Change the header based on administrator role access.

--- a/modules/custom/inope_policy_review/inope_policy_review.module
+++ b/modules/custom/inope_policy_review/inope_policy_review.module
@@ -211,7 +211,7 @@ function inope_policy_review_form_submit($form, &$form_state) {
  * Query the policy review table for any records related to the current
  * node, note status, and are from the current user.
  */
-function inope_policy_review_select_query($node, $account, $status = NULL) {
+function inope_policy_review_select_query($node, $account) {
 
   // Select query to get the latest node revision timestamp.
   $node_revision = db_query("
@@ -239,16 +239,11 @@ function inope_policy_review_select_query($node, $account, $status = NULL) {
  */
 function inope_policy_review_insert_query($node, $account, $text, $status) {
 
-  $results = inope_policy_review_select_query($node, $account, $status);
+  $results = inope_policy_review_select_query($node, $account);
 
   // If the entry already exists don't duplicate it.
-  if (!empty($results) &&
-      $results[0]->nid == $node->nid &&
-      $results[0]->vid == $node->vid &&
-      $results[0]->uid == $account->uid &&
-      $results[0]->note_status == $status &&
-      $results[0]->note == $text) {
-    drupal_set_message(t('You have previously submitted this response.'));
+  if (!empty($results)) {
+    drupal_set_message(t('You have previously submitted a response.'));
     $policy_review_id = 0;
   }
   else {

--- a/modules/custom/inope_policy_review/inope_policy_review.module
+++ b/modules/custom/inope_policy_review/inope_policy_review.module
@@ -75,10 +75,51 @@ function inope_policy_review_permission() {
 }
 
 /**
+ * Implements hook_form_alter().
+ */
+function inope_policy_review_form_alter(&$form, &$form_state, $form_id) {
+
+  global $user;
+  $account = $user;
+
+  // Store argument from the autoloader in hook_menu().
+  $node = $form_state['build_info']['args'][0];
+
+  // Check that we are only altering the inope policy review form.
+  if ($form_id == 'inope_policy_review_form') {
+
+    // Query the policy review table for any records related to the current
+    // node, unapproved notes, and are from the current user.
+    $results = db_select('policy_review', 'pr')
+      ->fields('pr')
+      ->condition('nid', $node->nid, '=')
+      ->condition('note_status', 0, '=')
+      ->condition('uid', $account->uid, '=')
+      ->execute()
+      ->fetchAssoc();
+
+    // If the active user has submitted something and is not an administrator
+    // clear the form items we don't want to show and show a message.
+    if (!empty($results) && !in_array('administrator', $account->roles)) {
+      $form['inope_policy_review_status_radio'] = array();
+      $form['inope_policy_review_changes_requested_textarea'] = array();
+      $form['inope_policy_review_submit'] = array();
+      $form['message'] = array(
+        '#type' => 'markup',
+        '#markup' => t('Thank you for your feedback!
+        Please check back often for additional review.'),
+      );
+    }
+  }
+}
+
+/**
  * The iNope Policy Review Form.
  */
 function inope_policy_review_form($form, &$form_state, $node) {
   global $user;
+
+  $account = $user;
 
   // Create radio button options (approved or changes requested).
   $status = array(
@@ -130,7 +171,7 @@ function inope_policy_review_form($form, &$form_state, $node) {
   // Store the uid for future use, not displayed to the user.
   $form['inope_policy_review_hidden_uid'] = array(
     '#type' => 'hidden',
-    '#value' => $user->uid,
+    '#value' => $account->uid,
   );
 
   // Create the submit button.
@@ -152,22 +193,57 @@ function inope_policy_review_form_submit($form, &$form_state) {
 
   // If 'I have reviewed this policy and approved it for use' is selected.
   if ($form_state['values']['inope_policy_review_status_radio'] == 0) {
-    drupal_set_message(t('Policy approved for use'));
-    // TODO: put this into the database.
+
+    // Only administrators should be able to approve notes.
+    if (in_array('administrator', $account->roles)) {
+
+      // Run an update query on the policy review table to set the note_status
+      // as approved where the fields are equal to the current node and are
+      // unapproved.
+      $updated_records = db_update('policy_review')
+        ->fields(array(
+          'note_status' => 1,
+        ))
+        ->condition('nid', $node->nid, '=')
+        ->condition('note_status', 0, '=')
+        ->execute();
+
+      drupal_set_message(t('Policy approved for use @number records updated', array(
+        '@number' => $updated_records,
+      )));
+    }
+    // Staff will receive this warning message.
+    else {
+      drupal_set_message(t('Please contact your administrator for approval.'),
+        'warning');
+    }
+
   }
   // If 'I have reviewed this policy and would like to see changes' is selected.
   elseif ($form_state['values']['inope_policy_review_status_radio'] == 1) {
+
+    // Make code more legible by setting a variable here.
+    $text = $form_state['values']['inope_policy_review_changes_requested_textarea'];
+
+    // Run an insert query on the policy review table for the new note.
+    $policy_review_id = db_insert('policy_review')
+      ->fields(array(
+        'nid' => $node->nid,
+        'vid' => $node->vid,
+        'uid' => $account->uid,
+        'note_status' => 0,
+        'note_submitted' => time(),
+        'note' => $text,
+      ))
+      ->execute();
+
+    // Thank the user for their request.
     drupal_set_message(
-      t('User : @userid : @username submitted the following change request:', array(
-        '@userid' => $account->uid,
+      t('Thank you @username for submitting the following change request:', array(
         '@username' => $account->name,
       )));
 
-    drupal_set_message($form_state['values']['inope_policy_review_changes_requested_textarea']);
-
-    drupal_set_message(t('Node ID : @nodeid', array('@nodeid' => $node->nid)));
-    drupal_set_message(t('Node VID : @nodevid', array('@nodevid' => $node->vid)));
-    // TODO: put this into the database.
+    drupal_set_message($text);
   }
   // If a bug is encountered.
   else {

--- a/modules/custom/inope_policy_review/inope_policy_review.module
+++ b/modules/custom/inope_policy_review/inope_policy_review.module
@@ -213,27 +213,22 @@ function inope_policy_review_form_submit($form, &$form_state) {
  */
 function inope_policy_review_select_query($node, $account, $status = NULL) {
 
-  // We need the ability to return all records regardless of status so we change
-  // the query based off of status = null or status = something defined.
-  if ($status == NULL) {
-    $results = db_query("
-    SELECT * FROM {policy_review} WHERE nid = :nid AND uid = :uid ORDER BY 
-    note_submitted DESC", array(
-      ':nid' => $node->nid,
-      ':uid' => $account->uid,
-    ))->fetchAll();
-  }
-  else {
-    $results = db_query("
-    SELECT * FROM {policy_review} WHERE nid = :nid AND note_status =
-    :note_status AND uid = :uid ORDER BY note_submitted DESC", array(
-      ':nid' => $node->nid,
-      ':note_status' => $status,
-      ':uid' => $account->uid,
-    ))->fetchAll();
-  }
+  // Select query to get the latest node revision timestamp.
+  $node_revision = db_query("
+  SELECT vid, timestamp FROM {node_revision} WHERE vid = :vid", array(
+    ':vid' => $node->vid,
+  ))->fetchObject();
 
-  return $results;
+  // Select query to get all records with a note_sumbitted >= vid_timestamp.
+  $policy_review_notes = db_query("
+  SELECT * FROM {policy_review} WHERE nid = :nid AND uid = :uid AND 
+  note_submitted >= :vid_timestamp ORDER BY note_submitted DESC", array(
+    ':nid' => $node->nid,
+    ':uid' => $account->uid,
+    ':vid_timestamp' => $node_revision->timestamp,
+  ))->fetchAll();
+
+  return $policy_review_notes;
 }
 
 /**

--- a/modules/custom/inope_policy_review/inope_policy_review.module
+++ b/modules/custom/inope_policy_review/inope_policy_review.module
@@ -20,6 +20,14 @@ function inope_policy_review_menu() {
     'type' => MENU_LOCAL_TASK,
   );
 
+  $items['admin/reports/inope'] = array(
+    'title' => 'iNope Report',
+    'description' => 'Review of all policy nodes.',
+    'page callback' => 'inope_policy_review_report_page',
+    'access arguments' => array('administer inope policy review'),
+    'type' => MENU_LOCAL_TASK,
+  );
+
   return $items;
 }
 
@@ -128,6 +136,22 @@ function inope_policy_review_page($node) {
 }
 
 /**
+ * Creates the iNope policy review report page.
+ */
+function inope_policy_review_report_page() {
+  $build = array();
+
+  $report_page = TRUE;
+
+  $build['table'] = array(
+    '#type' => 'markup',
+    '#markup' => inope_policy_review_table(NULL, NULL, $report_page),
+  );
+
+  return $build;
+}
+
+/**
  * Implements hook_permission().
  */
 function inope_policy_review_permission() {
@@ -135,6 +159,10 @@ function inope_policy_review_permission() {
     'view inope policy review' => array(
       'title' => t('View iNope Policy Review'),
       'description' => t('View the review tab on policy node pages'),
+    ),
+    'administer inope policy review' => array(
+      'title' => t('Administer iNope Policy Review'),
+      'description' => t('Administration pages for iNope policy review'),
     ),
   );
 }
@@ -157,7 +185,8 @@ function inope_policy_review_form($form, &$form_state, $node, $policy_review_id 
     $policy_review_note = inope_policy_review_select_query_one($policy_review_id);
 
     // Check user access then set default form values to old note values.
-    if ($account->uid == $policy_review_note->uid) {
+    if ($account->uid == $policy_review_note->uid ||
+        user_access('administer inope policy review')) {
       $status_radio_default_value = $policy_review_note->note_status;
       $changes_requested_textarea_default_value = $policy_review_note->note;
       $policy_review_id_default_value = $policy_review_note->policy_review_id;
@@ -444,32 +473,54 @@ function inope_policy_review_update_query(&$form_state) {
 /**
  * Build a table to display the data for the current node.
  */
-function inope_policy_review_table($node, $account) {
+function inope_policy_review_table($node, $account, $report_page = FALSE) {
   // Set table headers.
   $header = array(
     'Policy Review ID' => array(
       'data' => t('Policy Review ID'),
-      'field' => 'policy_review_id',
+      'field' => 'pr.policy_review_id',
     ),
     'Version' => array(
       'data' => t('Version'),
-      'field' => 'vid',
+      'field' => 'pr.vid',
     ),
     'Date' => array(
       'data' => t('Date'),
-      'field' => 'note_submitted',
+      'field' => 'pr.note_submitted',
       'sort' => 'desc',
     ),
     'Request Status' => array(
       'data' => t('Request Status'),
-      'field' => 'note_status',
+      'field' => 'pr.note_status',
     ),
     'Note' => array(
       'data' => t('Note'),
-      'field' => 'note',
+      'field' => 'pr.note',
     ),
-    '',
+    'Edit' => array(
+      'data' => '',
+    ),
   );
+
+  // Change the header based on administrator role access.
+  if (user_access('administer inope policy review')) {
+    $header = array(
+      'User' => array(
+        'data' => t('User'),
+        'field' => 'u.uid',
+      ),
+    ) + $header;
+  }
+
+  // Change the header based on report page is true.
+  if ($report_page == TRUE) {
+    $header = array(
+      'Node' => array(
+        'data' => t('Node'),
+        'field' => 'n.nid',
+      ),
+    ) + $header;
+  }
 
   // Create $rows variable.
   $rows = array();
@@ -480,22 +531,53 @@ function inope_policy_review_table($node, $account) {
   // Build a dynamic 'TableSort' query that uses the GET parameters to order the
   // table.  The TableSort is key, without it you need another way to change
   // your query based on the GET parameters passed.
-  $query = db_select('policy_review', 'pr')
-    ->fields('pr')
-    ->condition('uid', $account->uid, '=')
-    ->condition('nid', $node->nid, '=')
-    ->extend('TableSort')
-    ->orderByHeader($header);
+  //
+  // Change the query based on administrator role access.
+  if (user_access('administer inope policy review') && $report_page == TRUE) {
+
+    // View ALL records.
+    $query = db_select('policy_review', 'pr');
+    $query->join('users', 'u', 'pr.uid = u.uid');
+    $query->join('node', 'n', 'pr.nid = n.nid');
+    $query->fields('pr');
+    $query->fields('u', array('uid', 'name'));
+    $query->fields('n', array('nid', 'title'));
+    $query->extend('TableSort')->orderByHeader($header);
+    $query->execute();
+  }
+  elseif (user_access('administer inope policy review') && $report_page == FALSE) {
+
+    // View all records regardless of uid on a single node.
+    $query = db_select('policy_review', 'pr');
+    $query->join('users', 'u', 'pr.uid = u.uid');
+    $query->fields('pr');
+    $query->fields('u', array('uid', 'name'));
+    $query->condition('pr.nid', $node->nid, '=');
+    $query->extend('TableSort')->orderByHeader($header);
+    $query->execute();
+  }
+  else {
+
+    // Limit access to records based on logged in user.
+    $query = db_select('policy_review', 'pr')
+      ->fields('pr')
+      ->condition('uid', $account->uid, '=')
+      ->condition('nid', $node->nid, '=')
+      ->extend('TableSort')
+      ->orderByHeader($header);
+  }
 
   // Execute the query and store the results in a variable.
   $results = $query->execute();
+  $count = 0;
 
   // Process the results.
   foreach ($results as $result) {
-    $rows[] = array(
+
+    $rows[$count] = array(
       array(
         'data' => l($result->policy_review_id,
-                    'node/' . $node->nid . '/review',
+                    'node/' . $result->nid . '/review',
                     array('query' => array('id' => $result->policy_review_id))),
       ),
       array('data' => $result->vid),
@@ -504,10 +586,27 @@ function inope_policy_review_table($node, $account) {
       array('data' => $result->note),
       array(
         'data' => l(t('Edit'),
-                    'node/' . $node->nid . '/review',
+                    'node/' . $result->nid . '/review',
                     array('query' => array('id' => $result->policy_review_id))),
       ),
     );
+
+    // Change the rows based on administrator role access.
+    if (user_access('administer inope policy review')) {
+      array_unshift($rows[$count], array(
+        'data' => l($result->name, 'user/' . $result->uid),
+      ));
+    }
+
+    // Change the rows based on report page is TRUE.
+    if ($report_page == TRUE) {
+      array_unshift($rows[$count], array(
+        'data' => l($result->title, 'node/' . $result->nid),
+      ));
+    }
+
+    $count++;
+
   }
 
   // Have the theme_table() function build your new table.

--- a/modules/custom/inope_policy_review/inope_policy_review.module
+++ b/modules/custom/inope_policy_review/inope_policy_review.module
@@ -70,10 +70,10 @@ function inope_policy_review_page($node) {
       '#markup' => t('Thank you for your feedback!
       Please check back often for additional review.'),
     );
-  } 
+  }
   else {
-    // If no results build a blank form
-    $build['inope_policy_review_form'] 
+    // If no results build a blank form.
+    $build['inope_policy_review_form']
       = drupal_get_form('inope_policy_review_form', $node);
   }
 
@@ -170,7 +170,7 @@ function inope_policy_review_form_submit($form, &$form_state) {
   $account = user_load($form_state['values']['inope_policy_review_hidden_uid']);
   $node = node_load($form_state['values']['inope_policy_review_hidden_nid']);
   $text = check_plain($form_state['values']['inope_policy_review_changes_requested_textarea']);
-  
+
   // If 'I have reviewed this policy and approved it for use' is selected.
   if ($form_state['values']['inope_policy_review_status_radio'] == 0) {
 
@@ -207,47 +207,47 @@ function inope_policy_review_form_submit($form, &$form_state) {
 
 /**
  * Select query for the current node policy review notes.
- * 
+ *
  * Query the policy review table for any records related to the current
  * node, note status, and are from the current user.
  */
 function inope_policy_review_select_query($node, $account, $status = NULL) {
-  
+
   // We need the ability to return all records regardless of status so we change
   // the query based off of status = null or status = something defined.
   if ($status == NULL) {
-    $results = db_query(
-    "SELECT * FROM {policy_review} WHERE nid = :nid AND uid = :uid ORDER BY 
-     note_submitted DESC", array(
+    $results = db_query("
+    SELECT * FROM {policy_review} WHERE nid = :nid AND uid = :uid ORDER BY 
+    note_submitted DESC", array(
       ':nid' => $node->nid,
       ':uid' => $account->uid,
     ))->fetchAll();
-  } 
+  }
   else {
-    $results = db_query(
-    "SELECT * FROM {policy_review} WHERE nid = :nid AND note_status =
-     :note_status AND uid = :uid ORDER BY note_submitted DESC", array(
+    $results = db_query("
+    SELECT * FROM {policy_review} WHERE nid = :nid AND note_status =
+    :note_status AND uid = :uid ORDER BY note_submitted DESC", array(
       ':nid' => $node->nid,
       ':note_status' => $status,
       ':uid' => $account->uid,
     ))->fetchAll();
   }
-    
+
   return $results;
 }
 
 /**
  * Insert query to add a new policy review note or approve policy.
- * 
+ *
  * Only insert the new row if it is substantially a new request meaning that
- * some value other than the timestamp is different
+ * some value other than the timestamp is different.
  */
 function inope_policy_review_insert_query($node, $account, $text, $status) {
-  
+
   $results = inope_policy_review_select_query($node, $account, $status);
-  
-  // If the entry already exists don't duplicate it
-  if (!empty($results) && 
+
+  // If the entry already exists don't duplicate it.
+  if (!empty($results) &&
       $results[0]->nid == $node->nid &&
       $results[0]->vid == $node->vid &&
       $results[0]->uid == $account->uid &&
@@ -269,18 +269,18 @@ function inope_policy_review_insert_query($node, $account, $text, $status) {
       ))
       ->execute();
   }
-  
+
   return $policy_review_id;
 }
 
 /**
  * Update query if the user wants to update a record.
- * 
- * Currently this funtion is not called anywhere but it is avaliable for future 
+ *
+ * Currently this funtion is not called anywhere but it is avaliable for future
  * use.
  */
 function inope_policy_review_update_query($node, $account, $text, $timestamp) {
-  
+
   // Run an update query on the policy review table to change the note.
   $updated_records = db_update('policy_review')
     ->fields(array(
@@ -290,6 +290,6 @@ function inope_policy_review_update_query($node, $account, $text, $timestamp) {
     ->condition('uid', $account->uid, '=')
     ->condition('note_submitted', $timestamp, '=')
     ->execute();
-  
+
   return $updated_records;
 }

--- a/modules/custom/inope_policy_review/inope_policy_review.module
+++ b/modules/custom/inope_policy_review/inope_policy_review.module
@@ -20,15 +20,36 @@ function inope_policy_review_menu() {
     'type' => MENU_LOCAL_TASK,
   );
 
-  $items['admin/reports/inope'] = array(
-    'title' => 'iNope Report',
+  $items['admin/inope'] = array(
+    'title' => 'iNope',
+    'description' => 'Admin menu tab for sublinks.',
+    'page callback' => 'inope_policy_review_admin_links_page',
+    'access arguments' => array('administer inope policy review'),
+    'type' => MENU_NORMAL_ITEM,
+  );
+  
+  $items['admin/inope/report'] = array(
+    'title' => 'Policy Review Notes Report',
     'description' => 'Review of all policy nodes.',
     'page callback' => 'inope_policy_review_report_page',
     'access arguments' => array('administer inope policy review'),
-    'type' => MENU_LOCAL_TASK,
+    'type' => MENU_NORMAL_ITEM,
   );
 
   return $items;
+}
+
+/**
+ * Build a page with admin links.
+ */
+function inope_policy_review_admin_links_page() {
+  $build = array(
+    'header_text' => array(
+      '#type' => 'markup',
+      '#markup' => '<p>' . l(t('Policy Review Notes Report'), 'admin/inope/report') . '</p>',
+    ),
+  );
+  return $build;
 }
 
 /**

--- a/modules/features/feature_inope_policy/feature_inope_policy.features.user_permission.inc
+++ b/modules/features/feature_inope_policy/feature_inope_policy.features.user_permission.inc
@@ -10,6 +10,15 @@
 function feature_inope_policy_user_default_permissions() {
   $permissions = array();
 
+  // Exported permission: 'administer inope policy review'.
+  $permissions['administer inope policy review'] = array(
+    'name' => 'administer inope policy review',
+    'roles' => array(
+      'administrator' => 'administrator',
+    ),
+    'module' => 'inope_policy_review',
+  );
+
   // Exported permission: 'create inope_policy content'.
   $permissions['create inope_policy content'] = array(
     'name' => 'create inope_policy content',

--- a/modules/features/feature_inope_policy/feature_inope_policy.info
+++ b/modules/features/feature_inope_policy/feature_inope_policy.info
@@ -13,6 +13,7 @@ features[features_api][] = api:2
 features[field_base][] = body
 features[field_instance][] = node-inope_policy-body
 features[node][] = inope_policy
+features[user_permission][] = administer inope policy review
 features[user_permission][] = create inope_policy content
 features[user_permission][] = delete any inope_policy content
 features[user_permission][] = delete own inope_policy content

--- a/modules/features/feature_inope_policy/feature_inope_policy.strongarm.inc
+++ b/modules/features/feature_inope_policy/feature_inope_policy.strongarm.inc
@@ -21,7 +21,7 @@ function feature_inope_policy_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'comment_default_mode_inope_policy';
-  $strongarm->value = 1;
+  $strongarm->value = 0;
   $export['comment_default_mode_inope_policy'] = $strongarm;
 
   $strongarm = new stdClass();
@@ -42,14 +42,14 @@ function feature_inope_policy_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'comment_inope_policy';
-  $strongarm->value = '2';
+  $strongarm->value = '1';
   $export['comment_inope_policy'] = $strongarm;
 
   $strongarm = new stdClass();
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'comment_preview_inope_policy';
-  $strongarm->value = '1';
+  $strongarm->value = '0';
   $export['comment_preview_inope_policy'] = $strongarm;
 
   $strongarm = new stdClass();


### PR DESCRIPTION
This PR seeks to:
- Create new permission for administrator reports.
- Allow administrators to see all feedback.
- Build an administrator report.
- Add new columns to table based on permissions and page.
- Sortable by new columns which required joins.
## Steps to test:
- Run update.php on existing sites.
- Verify you already have two policy nodes and two users (admin and staff)
- Create a few revisions of each node with submissions from both users
- Start with staff and verify that staff can only see their own submissions
  - Staff should also be able to edit their own submissions
  - Attempt to go to /admin/reports/inope
  - If you got an access denied as staff this is correct
- Now log in as the administrator
  - Go to /admin/reports/inope
  - Verify that the report contains additional columns called node and user
  - Verify that columns are sortable
  - Verify that default sort is by date
